### PR TITLE
Update to awscli v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM docker:19.03.4
 
-RUN apk update \
-  && apk upgrade \
-  && apk add --no-cache --update python3 python py-pip coreutils \
-  && rm -rf /var/cache/apk/* \
-  && pip install awscli \
-  && apk --purge -v del py-pip
+RUN apk update
+RUN apk upgrade
+RUN apk add --no-cache --update python3 python py-pip coreutils curl
+RUN rm -rf /var/cache/apk/*
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+RUN apk --purge -v del py-pip
 
 ADD run.py /run.py
 ADD entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Old builds were failing due to incompatible versions of PyYAML (which is a dependency of awscli) and cython_sources. This commit updates awscli to use v2 which is the suggested update here: https://github.com/aws/aws-cli/issues/8036#issuecomment-1638544754.

This is a potentially breaking change.